### PR TITLE
Fix timer draining rate

### DIFF
--- a/include/chip8/VirtualMachine.hpp
+++ b/include/chip8/VirtualMachine.hpp
@@ -13,7 +13,6 @@ namespace chip8 {
     Stack stack;
     RandomNumberGenerator rng;
     GraphicsBuffer graphics;
-    bool graphicsAreDirty;
     KeyboardInputs keyboard;
     bool awaitingKeypress;
     Byte nextKeypressRegister;
@@ -27,7 +26,6 @@ namespace chip8 {
       , stack{}
       , rng{[](Byte seed) { return 7; }}
       , graphics{}
-      , graphicsAreDirty{false}
       , keyboard{}
       , awaitingKeypress{false}
       , nextKeypressRegister{0}

--- a/src/chip8/Functions.cpp
+++ b/src/chip8/Functions.cpp
@@ -49,14 +49,6 @@ namespace chip8 {
 
   void cycle(VirtualMachine & vm) {
     if(!vm.awaitingKeypress) {
-      if(vm.timers.delay > 0) {
-        vm.timers.delay -= 1;
-      }
-
-      if(vm.timers.sound > 0) {
-        vm.timers.sound -= 1;
-      }
-
       execute(vm, fetch(vm));
     }
   }

--- a/src/chip8/Opcodes.cpp
+++ b/src/chip8/Opcodes.cpp
@@ -24,7 +24,6 @@ namespace chip8 {
 
     void clearScreen(VirtualMachine & vm, Instruction instruction) {
       vm.graphics.fill(0);
-      vm.graphicsAreDirty = true;
     }
 
     void returnFromSubroutine(VirtualMachine & vm, Instruction instruction) {
@@ -359,8 +358,6 @@ namespace chip8 {
           vm.registers[0xF] = 0;
         }
       }
-
-      vm.graphicsAreDirty = true;
     }
 
     void disambiguate0xE(VirtualMachine & vm, Instruction instruction) {

--- a/src/host/Application.cpp
+++ b/src/host/Application.cpp
@@ -55,14 +55,28 @@ namespace host {
         SDL_RenderClear(renderer.get());
       }
 
+      int32_t count = 0;
+
       while(!quit) {
         handleEvents();
 
         if(!paused) {
+          // update timers at 60hz
+          if (count % 17 == 0) {
+            if(vm.timers.delay > 0) {
+              vm.timers.delay -= 1;
+            }
+
+            if(vm.timers.sound > 0) {
+              vm.timers.sound -= 1;
+            }
+          }
+
           updateEmulator();
           updateScreen();
         }
 
+        count++;
         SDL_Delay(1);
       }
     }
@@ -203,7 +217,7 @@ namespace host {
 
   void Application::updateScreen() {
     // Clear screen with black.
-    if(renderer && vm.graphicsAreDirty) {
+    if(renderer) {
       SDL_SetRenderDrawColor(renderer.get(), 0, 0, 0, SDL_ALPHA_OPAQUE);
       SDL_RenderClear(renderer.get());
       SDL_SetRenderDrawColor(renderer.get(), 255, 255, 255, SDL_ALPHA_OPAQUE);

--- a/src/host/Application.cpp
+++ b/src/host/Application.cpp
@@ -2,6 +2,7 @@
 #include "chip8/Functions.hpp"
 #include "chip8/VirtualMachine.hpp"
 #include <iostream>
+#include <chrono>
 
 namespace host {
 
@@ -55,14 +56,21 @@ namespace host {
         SDL_RenderClear(renderer.get());
       }
 
-      int32_t count = 0;
+      // 60hz
+      using frame_period = std::chrono::duration<long long, std::ratio<1, 60>>;
+      auto prev = std::chrono::high_resolution_clock::now();
+      auto current = prev;
+      
 
       while(!quit) {
         handleEvents();
 
+        current = std::chrono::high_resolution_clock::now();
+        auto difference = current - prev;
+
         if(!paused) {
-          // update timers at 60hz
-          if (count % 17 == 0) {
+          if (difference > frame_period{1}) {
+            prev = current;
             if(vm.timers.delay > 0) {
               vm.timers.delay -= 1;
             }
@@ -75,9 +83,6 @@ namespace host {
           updateEmulator();
           updateScreen();
         }
-
-        count++;
-        SDL_Delay(1);
       }
     }
 


### PR DESCRIPTION
Also, removed dirty flag as it wasn't doing anything and clearing seems to worsen. Both invaders and breakout seemed to play fairly well with this.
